### PR TITLE
Implement scene-synthesis Environment

### DIFF
--- a/src/scene_synthesis/__init__.py
+++ b/src/scene_synthesis/__init__.py
@@ -1,5 +1,6 @@
 from .directivities import CardioidDirectivity as CardioidDirectivity
 from .directivities import OmniDirectivity as OmniDirectivity
+from .environments import Environment as Environment
 from .microphones import Microphone as Microphone
 from .scene import Scene as Scene
 from .sources import Source as Source

--- a/src/scene_synthesis/environments.py
+++ b/src/scene_synthesis/environments.py
@@ -54,7 +54,8 @@ class Environment(HasStrictTraits):
             Coordinates of the first set of points with shape ``(3, N)``.
         mpos : :class:`float` or :class:`numpy.ndarray`, optional
             Coordinates of the second set of points. A scalar is interpreted
-            as the origin ``(0, 0, 0)``. Array input must have shape ``(3, M)``.
+            as the origin ``(0, 0, 0)``. Array input may have shape ``(3,)``
+            for a single point or ``(3, M)`` for multiple points.
 
         Returns
         -------
@@ -64,6 +65,20 @@ class Environment(HasStrictTraits):
         """
         if np.isscalar(mpos):
             mpos = np.array((0.0, 0.0, 0.0), dtype=np.float64)[:, np.newaxis]
+        else:
+            mpos = np.asarray(mpos, dtype=np.float64)
+            if mpos.ndim == 1:
+                if mpos.shape[0] != 3:
+                    msg = f'mpos must have length 3 when passed as a 1D array; got shape {mpos.shape}'
+                    raise ValueError(msg)
+                mpos = mpos[:, np.newaxis]
+            elif mpos.ndim == 2:
+                if mpos.shape[0] != 3:
+                    msg = f'mpos must have shape (3, M); got shape {mpos.shape}'
+                    raise ValueError(msg)
+            else:
+                msg = f'mpos must be a scalar, shape (3,), or shape (3, M); got shape {mpos.shape}'
+                raise ValueError(msg)
 
         distances = dist_mat(np.ascontiguousarray(gpos), np.ascontiguousarray(mpos))
         if distances.shape[1] == 1:

--- a/src/scene_synthesis/environments.py
+++ b/src/scene_synthesis/environments.py
@@ -1,38 +1,81 @@
 """Environment models for acoustic propagation."""
 
 import numpy as np
-from acoular import Environment as AcoularEnvironment
+from traits.api import CArray, Float, HasStrictTraits, Union
 
 
-class Environment(AcoularEnvironment):
-    """Scene-synthesis environment.
+def dist_mat(gpos, mpos):
+    """Compute the distance matrix between source and microphone positions.
 
-    This class currently extends :class:`acoular.Environment` with a small,
-    scene-synthesis-oriented API for querying apparent propagation distances
-    and geometric spreading factors.
+    Parameters
+    ----------
+    gpos : :class:`numpy.ndarray`
+        Positions of ``N`` points with shape ``(3, N)``.
+    mpos : :class:`numpy.ndarray`
+        Positions of ``M`` points with shape ``(3, M)``.
+
+    Returns
+    -------
+    :class:`numpy.ndarray`
+        Distance matrix with shape ``(N, M)``.
+    """
+    _, mics = mpos.shape
+    _, points = gpos.shape
+    distances = np.empty((points, mics), dtype=np.result_type(gpos, mpos, np.float64))
+
+    for point_idx in range(points):
+        point = gpos[:, point_idx]
+        deltas = point[:, np.newaxis] - mpos
+        distances[point_idx, :] = np.sqrt(np.sum(deltas * deltas, axis=0))
+
+    return distances
+
+
+class Environment(HasStrictTraits):
+    """A simple acoustic environment without flow.
+
+    This class mirrors the free-field behaviour needed from
+    :class:`acoular.Environment` while keeping the implementation local to
+    scene-synthesis.
     """
 
-    def apparent_r(self, spos, mpos=0.0):
-        """Return apparent propagation distances between source and mic positions.
+    #: Speed of sound in the environment.
+    c = Float(343.0)
+
+    #: Region of interest for calculations. Reserved for future use.
+    roi = Union(None, CArray)
+
+    def _r(self, gpos, mpos=0.0):
+        """Compute apparent distances between source and microphone positions.
 
         Parameters
         ----------
-        spos : :class:`numpy.ndarray`
-            Source positions with shape ``(3, N)``.
+        gpos : :class:`numpy.ndarray`
+            Coordinates of the first set of points with shape ``(3, N)``.
         mpos : :class:`float` or :class:`numpy.ndarray`, optional
-            Microphone positions with shape ``(3, M)``. A scalar is treated as
-            the origin, matching :class:`acoular.Environment` behaviour.
+            Coordinates of the second set of points. A scalar is interpreted
+            as the origin ``(0, 0, 0)``. Array input must have shape ``(3, M)``.
 
         Returns
         -------
         :class:`numpy.ndarray`
-            Apparent propagation distances. The shape matches the behaviour of
-            :meth:`acoular.Environment._r`.
+            Distances with shape ``(N,)`` for one microphone position or
+            ``(N, M)`` for multiple microphone positions.
         """
+        if np.isscalar(mpos):
+            mpos = np.array((0.0, 0.0, 0.0), dtype=np.float64)[:, np.newaxis]
+
+        distances = dist_mat(np.ascontiguousarray(gpos), np.ascontiguousarray(mpos))
+        if distances.shape[1] == 1:
+            return distances[:, 0]
+        return distances
+
+    def apparent_r(self, spos, mpos=0.0):
+        """Return apparent propagation distances between source and mic positions."""
         return self._r(spos, mpos)
 
     def spread(self, spos, mpos=0.0):
-        """Return the geometric spreading factor for source-mic pairs.
+        """Return geometric spreading factors for source-mic pairs.
 
         The current implementation uses simple spherical spreading, i.e.
         ``1 / apparent_r``.

--- a/src/scene_synthesis/environments.py
+++ b/src/scene_synthesis/environments.py
@@ -1,0 +1,41 @@
+"""Environment models for acoustic propagation."""
+
+import numpy as np
+from acoular import Environment as AcoularEnvironment
+
+
+class Environment(AcoularEnvironment):
+    """Scene-synthesis environment.
+
+    This class currently extends :class:`acoular.Environment` with a small,
+    scene-synthesis-oriented API for querying apparent propagation distances
+    and geometric spreading factors.
+    """
+
+    def apparent_r(self, spos, mpos=0.0):
+        """Return apparent propagation distances between source and mic positions.
+
+        Parameters
+        ----------
+        spos : :class:`numpy.ndarray`
+            Source positions with shape ``(3, N)``.
+        mpos : :class:`float` or :class:`numpy.ndarray`, optional
+            Microphone positions with shape ``(3, M)``. A scalar is treated as
+            the origin, matching :class:`acoular.Environment` behaviour.
+
+        Returns
+        -------
+        :class:`numpy.ndarray`
+            Apparent propagation distances. The shape matches the behaviour of
+            :meth:`acoular.Environment._r`.
+        """
+        return self._r(spos, mpos)
+
+    def spread(self, spos, mpos=0.0):
+        """Return the geometric spreading factor for source-mic pairs.
+
+        The current implementation uses simple spherical spreading, i.e.
+        ``1 / apparent_r``.
+        """
+        distances = np.asarray(self.apparent_r(spos, mpos), dtype=float)
+        return np.reciprocal(distances)

--- a/src/scene_synthesis/scene.py
+++ b/src/scene_synthesis/scene.py
@@ -1,7 +1,7 @@
 import numpy as np
-from acoular import Environment
 from traits.api import CList, HasStrictTraits, Instance
 
+from scene_synthesis.environments import Environment
 from scene_synthesis.microphones import Microphone
 from scene_synthesis.sources import Source
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,47 @@
+"""Unit tests for the scene-synthesis environment class."""
+
+import numpy as np
+import scene_synthesis as ss
+
+
+def test_environment_apparent_r_matches_euclidean_distance():
+    """``Environment.apparent_r`` should match Euclidean distance in free field."""
+    environment = ss.Environment(c=343.0)
+
+    spos = np.array([[1.0], [0.0], [0.0]])
+    mpos = np.array([[0.0], [0.0], [0.0]])
+
+    distances = environment.apparent_r(spos, mpos)
+
+    np.testing.assert_allclose(distances, np.array([1.0]))
+
+
+def test_environment_spread_is_inverse_distance():
+    """``Environment.spread`` should implement spherical spreading ``1 / r``."""
+    environment = ss.Environment(c=343.0)
+
+    spos = np.array([[2.0], [0.0], [0.0]])
+    mpos = np.array([[0.0], [0.0], [0.0]])
+
+    spread = environment.spread(spos, mpos)
+
+    np.testing.assert_allclose(spread, np.array([0.5]))
+
+
+def test_environment_spread_supports_multiple_microphones():
+    """``Environment.spread`` should broadcast over multiple microphone positions."""
+    environment = ss.Environment(c=343.0)
+
+    spos = np.array([[1.0], [0.0], [0.0]])
+    mpos = np.array(
+        [
+            [0.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 0.0],
+        ]
+    )
+
+    spread = environment.spread(spos, mpos)
+    expected = np.array([[1.0, 1.0 / np.sqrt(2.0)]])
+
+    np.testing.assert_allclose(spread, expected)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -28,6 +28,18 @@ def test_environment_spread_is_inverse_distance():
     np.testing.assert_allclose(spread, np.array([0.5]))
 
 
+def test_environment_accepts_single_microphone_position_as_1d_array():
+    """``Environment._r`` should accept a single microphone position as ``(3,)``."""
+    environment = ss.Environment(c=343.0)
+
+    spos = np.array([[1.0], [0.0], [0.0]])
+    mpos = np.array([0.0, 0.0, 0.0])
+
+    distances = environment.apparent_r(spos, mpos)
+
+    np.testing.assert_allclose(distances, np.array([1.0]))
+
+
 def test_environment_spread_supports_multiple_microphones():
     """``Environment.spread`` should broadcast over multiple microphone positions."""
     environment = ss.Environment(c=343.0)

--- a/tests/test_fly_around.py
+++ b/tests/test_fly_around.py
@@ -35,7 +35,7 @@ def test_fly_around_maneuver():
     mic = synth.Microphone()
 
     scene = synth.Scene()
-    scene.environment = ac.Environment(c=c)
+    scene.environment = synth.Environment(c=c)
     scene.microphones = [mic]
     scene.sources = [source]
 


### PR DESCRIPTION
## Summary

This PR implements a local `scene_synthesis.Environment` class and integrates it into the package.

It addresses **#14** by adding an environment object to `scene_synthesis` itself instead of relying on `acoular.Environment` directly.

## What changed

- Added `src/scene_synthesis/environments.py` with a self-contained free-field `Environment` implementation:
  - `c`
  - `roi`
  - `_r(gpos, mpos=0.0)`
  - `apparent_r(spos, mpos=0.0)`
  - `spread(spos, mpos=0.0)`
- Added a local `dist_mat(...)` helper for distance-matrix computation.
- Exported `Environment` from `scene_synthesis.__init__`.
- Updated `Scene.environment` to use `scene_synthesis.environments.Environment`.
- Updated the existing fly-around test to instantiate `scene_synthesis.Environment`.
- Added `tests/test_environment.py` covering:
  - `apparent_r` for a simple free-field distance
  - `spread == 1 / r`
  - broadcasting over multiple microphone positions

## Motivation

Issue #14 asks for an `Environment` class in this package that provides the expected API and leaves room for later work on spreading / flow-aware behavior.

This PR introduces the basic free-field implementation locally, which also gives us a clean place to extend environment behavior in future issues (e.g. flow-aware spreading in #10).

## Notes

- This PR intentionally keeps the implementation minimal and focused on the currently needed free-field behavior.
- The `spread(...)` method currently implements simple spherical spreading `1 / r`.
- More advanced environment models and flow-aware spreading can build on this later.

## Issue linkage

Closes #14
