### PR TITLE
Adds Frame of Reference over Time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ readme = "README.md"
 authors = [
     { name = "Art Pelling", email = "a.pelling@tu-berlin.de" }
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "acoular>=26.01",
     "matplotlib>=3.10.7",
     "pyqt6>=6.10.0",
+    "scipy>=1.16.0",
 ]
 
 [dependency-groups]
@@ -36,7 +37,7 @@ typeCheckingMode = 'off'
 
 [tool.uv.sources]
 #acoular = { path = "../acoular", editable =true }
-acoular = { git = "https://github.com/acoular/acoular", rev = "42992470402b5a63f6d88abe035c40baae448691" }
+#acoular = { git = "https://github.com/acoular/acoular", rev = "42992470402b5a63f6d88abe035c40baae448691" }
 
 [tool.pytest.ini_options]
 testpaths = "tests"

--- a/scripts/forot_demo.ipynb
+++ b/scripts/forot_demo.ipynb
@@ -1,0 +1,492 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f66104c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from abc import ABC, abstractmethod\n",
+    "from typing import Self\n",
+    "from copy import deepcopy\n",
+    "import itertools\n",
+    "\n",
+    "import numpy as np\n",
+    "from numpy.typing import NDArray, ArrayLike\n",
+    "# scipy >= 1.16\n",
+    "from scipy.spatial.transform import RigidTransform, Rotation as ScipyRotation\n",
+    "from scipy.interpolate import make_interp_spline\n",
+    "\n",
+    "import matplotlib.animation\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from scene_synthesis import UniformLinearTrajectory, SplineTrajectory, CircularTrajectory\n",
+    "from scene_synthesis import Translation, Rotation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cc46d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b58ea45",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# For displaying purposes only\n",
+    "# Some code of this cell was taken from the scipy-documentation:\n",
+    "# https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.RigidTransform.html#scipy.spatial.transform.RigidTransform\n",
+    "# The copyright of this remains with the SciPy Community and  is subject to the following license:\n",
+    "\n",
+    "# Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.\n",
+    "# All rights reserved.\n",
+    "\n",
+    "# Redistribution and use in source and binary forms, with or without\n",
+    "# modification, are permitted provided that the following conditions\n",
+    "# are met:\n",
+    "\n",
+    "# 1. Redistributions of source code must retain the above copyright\n",
+    "#    notice, this list of conditions and the following disclaimer.\n",
+    "\n",
+    "# 2. Redistributions in binary form must reproduce the above\n",
+    "#    copyright notice, this list of conditions and the following\n",
+    "#    disclaimer in the documentation and/or other materials provided\n",
+    "#    with the distribution.\n",
+    "\n",
+    "# 3. Neither the name of the copyright holder nor the names of its\n",
+    "#    contributors may be used to endorse or promote products derived\n",
+    "#    from this software without specific prior written permission.\n",
+    "\n",
+    "# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n",
+    "# \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n",
+    "# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n",
+    "# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n",
+    "# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n",
+    "# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n",
+    "# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n",
+    "# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n",
+    "# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n",
+    "# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n",
+    "# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
+    "plt.rcParams[\"animation.html\"] = \"jshtml\"\n",
+    "plt.rcParams['figure.dpi'] = 150\n",
+    "plt.ioff()\n",
+    "\n",
+    "N = 50\n",
+    "t_interval=(-1, 2)\n",
+    "\n",
+    "all_times = np.linspace(*t_interval, N)\n",
+    "\n",
+    "colors = (\"#FF6666\", \"#005533\", \"#1199EE\")  # Colorblind-safe RGB\n",
+    "\n",
+    "def prepare_plot(ax):\n",
+    "    for axis, c in zip((ax.xaxis, ax.yaxis, ax.zaxis), colors):\n",
+    "        axlabel = axis.axis_name\n",
+    "        axis.set_label_text(axlabel)\n",
+    "        axis.label.set_color(c)\n",
+    "        axis.line.set_color(c)\n",
+    "        axis.set_tick_params(colors=c)\n",
+    "\n",
+    "        ax.set(xlim3d=(-10, 10))\n",
+    "        ax.set(ylim3d=(-5, 15))\n",
+    "        ax.set(zlim3d=(-10, 10))\n",
+    "\n",
+    "def plot_trajectory(ax, traj, c='black'):\n",
+    "\n",
+    "        all_xpos = traj.location(all_times)\n",
+    "\n",
+    "        def plotter(t):\n",
+    "            ax.plot(*all_xpos, color=c, lw=0.5)\n",
+    "            #ax.plot(xs=all_xpos[:,0], ys=all_xpos[:,1], zs=all_xpos[:,2], c, lw=0.5)\n",
+    "\n",
+    "            location = traj.location(t)\n",
+    "            velocity = traj.velocity(t) / 5\n",
+    "            ax.scatter(*location, marker='o', color=c)\n",
+    "\n",
+    "            ax.plot(*zip(location, location+velocity), lw=2, color='grey')\n",
+    "\n",
+    "        return plotter\n",
+    "\n",
+    "\n",
+    "def plot_reference_frame(ax, ref_frame, name, scale=1):\n",
+    "\n",
+    "    #loc = np.array([t, t])\n",
+    "    def plotter(tf_t):\n",
+    "\n",
+    "        tf = ref_frame.rigid_transform(tf_t)\n",
+    "        tf_t, tf_r = tf.as_components()\n",
+    "\n",
+    "        for i, c in enumerate(colors):\n",
+    "            line = np.zeros((2, 3))\n",
+    "            line[1, i] = scale\n",
+    "            line_rot = tf.apply(line)\n",
+    "            line_plot = line_rot #+ loc\n",
+    "            ax.plot(line_plot[:, 0], line_plot[:, 1], line_plot[:, 2], c)\n",
+    "            ax.text(*tf_t, s=name, color=\"k\", va=\"center\", ha=\"center\",\n",
+    "                    bbox={\"fc\": \"w\", \"alpha\": 0.8, \"boxstyle\": \"circle\"})\n",
+    "    return plotter\n",
+    "\n",
+    "def create_animation(traj_list=None, rf_dict=None):\n",
+    "\n",
+    "    traj_list = traj_list if traj_list is not None else list()\n",
+    "    rf_dict = rf_dict if rf_dict is not None else dict()\n",
+    "\n",
+    "    N = 100\n",
+    "    t_interval=(-1, 2)\n",
+    "    colors = plt.cm.tab10.colors\n",
+    "\n",
+    "    fig, ax = plt.subplots(subplot_kw={\"projection\": \"3d\"})\n",
+    "\n",
+    "    all_times = np.linspace(*t_interval, N)\n",
+    "    line_plotter = [plot_trajectory(ax, tr, c) for tr, c in zip(traj_list, itertools.cycle(colors))]\n",
+    "    rf_plotter = [plot_reference_frame(ax, rf, name, 5) for name, rf in rf_dict.items()]\n",
+    "\n",
+    "    def animate(t):\n",
+    "        plt.cla()\n",
+    "\n",
+    "        prepare_plot(ax)\n",
+    "\n",
+    "        [plotter(t) for plotter in line_plotter]\n",
+    "        [plotter(t) for plotter in rf_plotter]\n",
+    "\n",
+    "\n",
+    "    return matplotlib.animation.FuncAnimation(fig, animate, frames=all_times, interval=(all_times[1]-all_times[0]) * 1000)\n",
+    "    #return animate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "282be3f9",
+   "metadata": {},
+   "source": [
+    "# Representation of Frame of References over Time (FOROT)\n",
+    "\n",
+    "## Mathematical Background and Notation\n",
+    "\n",
+    "A *Trajectory* is a function $\\phi: \\mathbb{R}\\rightarrow\\mathbb{R}^3$, yielding some position vector for every point in time $t \\mapsto \\mathbf{x}$. Typically we want $\\mathbf{x}$ to be expressed in the same *stationary reference frame* as the microphone locations, called here *global reference frame*. $$\\mathbf{x} = x_1\\mathbf{e}_1 +  x_2\\mathbf{e}_2 +  x_3\\mathbf{e}_3$$\n",
+    "\n",
+    "However, we also want to be able to map a whole set of points that are fixed to some moving body to the global reference frame. \n",
+    "\n",
+    "This is where the *frame of reference over time* comes in. With it, we can express the motion of the whole source region directly without restricting ourselves to a single point. *Any* point with constant coordinates in this FOROT is automatically fixed to whatever we are focussing on.\n",
+    "\n",
+    "### Coordinate Transformation\n",
+    "We only consider *Rigid Transformation* (*Isometries*), which consist of a *Rotation* and *Translation* (shift by offset). \n",
+    "*Rigid Transformation* are appropriate for describing the movement of solid bodies, as they preserve distances and angles.\n",
+    "\n",
+    "Usually, a spatial transformation $S: \\mathbb{R}^3\\rightarrow\\mathbb{R}^3$ just maps one point expressed in local coordinates to its counterpart in global coordinates $\\mathbf{x_L} \\rightarrow \\mathbf{x_G}$\n",
+    "\n",
+    "In our case this transformation $R$ is not constant, it also depends on time: \n",
+    "$$(t, \\mathbf{x_L})\\mapsto\\mathbf{x_G}$$\n",
+    "$$R: (\\mathbb{R}, \\mathbb{R}^3)\\rightarrow\\mathbb{R}^3$$\n",
+    "\n",
+    "This way to express it shows that we can retrieve a trajectory for any point by supplying some point fixed to the frame of reference $\\phi_\\mathbf{x_L} = R(\\cdot, \\mathbf{x_L})$. We can also retrieve a normal coordinate transform by supplying a time $S_t = R(t, \\cdot)$\n",
+    "\n",
+    "*This is not new information and implicitly is build into Acoulars MovingGrid. \n",
+    "But it does motivate the class structure, which is why it's good to explicitly write it out.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0be96cf5",
+   "metadata": {},
+   "source": [
+    "## Trajectory \n",
+    "\n",
+    "So far, we provide three different types of `Trajectory`s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d82cfa0d",
+   "metadata": {},
+   "source": [
+    "#### Unform Linear Trajectory\n",
+    "Has constant velocity $\\mathbf{v}_0 = \\frac{\\partial}{\\partial t}\\phi(t)$ and initial position $\\phi(t=0)=\\mathbf{x}_0 $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d37b55f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ult = UniformLinearTrajectory(x0=(0.,5.,0.), v0=(5.,0.,0.))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e734d71",
+   "metadata": {},
+   "source": [
+    "#### Trajectory through interpolating B-Spline "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8187246d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_rp = [[-5, 5, 0], [0, 5, 0], [5, 10, 5], [10, 10, 5]]\n",
+    "spt = SplineTrajectory(times=[-1, -0.2, 1.2, 2], positions=_rp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8358f803",
+   "metadata": {},
+   "source": [
+    "#### Circular Trajectory\n",
+    "\n",
+    "Circular Trajectory is defined by some initial position and an axis of rotation.\n",
+    "The axis of rotation is defined by some point on it called fixpoint and its direction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da10da34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct1 = CircularTrajectory(ref_pos=(0.,0.,0), rev_per_sec=1., axis_dir=(1.,0.,0), fixpoint=(0.,0.,5.))\n",
+    "ct2 = CircularTrajectory(ref_pos=(5.,0.,0.), rev_per_sec=1., axis_dir=(1.,1.,1.), fixpoint=(0.,0.,0.))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e283ddc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The plots take quite some time to render!\n",
+    "create_animation([ult, spt, ct1, ct2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e0320ba",
+   "metadata": {},
+   "source": [
+    "## FOROT\n",
+    "For now, only two reference frames (`Translation`, `Rotation`) are implemented.\n",
+    "\n",
+    "*For those two classes, the name denotes the part of the transformation which depends on time. E.g. `Translation` is made up of a translation (shift) which varies with time and a constant rotation. `Rotation` is made up of a constant translation (shift) and a rotation around some axis by some frequency.*\n",
+    "\n",
+    "Other reference frames could somewhat easily be added. Ideas for future reference frames are:\n",
+    "- a composition of reference frames: This would allow e.g. a rotor that moves through space.\n",
+    "- a rotation that has a nonconstant angular frequency \n",
+    "- translation where the orientation follows the curve (similar to Acoulars `rvec`)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "712f2e88",
+   "metadata": {},
+   "source": [
+    "Note that there no direct mapping $(t, \\mathbf{x_L})\\rightarrow\\mathbf{x_G}$ is required. \n",
+    "Typically, one only ever needs either to transform\n",
+    "- a single point at many discrete points in time\n",
+    "- or a whole set of points (e.g. the grid) at a single point in time.\n",
+    "\n",
+    "This is reflected by the two methods `.trajectory(...)` and `.ref_frame(...)` respectively.\n",
+    "Because of this, both use cases can be implemented efficiently, in most cases without \n",
+    "slow for loops.\n",
+    "\n",
+    "*To map a single point $\\mathbf{x_L}$ at some point in time $t$, one can use two ways*\n",
+    "```python\n",
+    "#rf is object of some subtype of LocalReferenceFrame\n",
+    "x_gobal = rf.trajectory(x_local).location(t)\n",
+    "x_gobal = rf.rigid_transform(t).apply(x_local)\n",
+    "```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42efa239",
+   "metadata": {},
+   "source": [
+    "### Translation\n",
+    "\n",
+    "The *rigid transformation* of `Translation` consists of a time dependent shift, which is defined by its `origin_traj`-attribute.  \n",
+    "`origin_traj` defines the path of the origin of the *local reference frame* and can itself be of any subclass of `Trajectory`,\n",
+    "i.e. the reference frame can follow some arbitrary path.\n",
+    "\n",
+    "Note that it also applies some rotation (constant over time) first, here called `orientation`. An application is e.g. the definition of some (large) \n",
+    "aircraft, which moves along a path and has some orientation that does not change in short time frames. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8c4bafd",
+   "metadata": {},
+   "source": [
+    "#### Example\n",
+    "\n",
+    "The Translation can be based on any type of Trajectory object,\n",
+    "including UniformLinearTrajectory, SplineTrajectory\n",
+    "and CircularTrajectory.\n",
+    "\n",
+    "Here, they all have different orientation_angles, which results in the axis pointing in other directions than the original frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1efaf29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "translation_ult = Translation(origin_traj=ult, orientation_angles=(0,0,45))\n",
+    "translation_sp = Translation(origin_traj=spt, orientation_angles=[90,0,90])\n",
+    "translation_ct = Translation(origin_traj=ct2, orientation_angles=[0,0,0])\n",
+    "\n",
+    "translation_dict = {\n",
+    "        'ult': translation_ult,\n",
+    "        'sp': translation_sp,\n",
+    "        'ct': translation_ct,\n",
+    "    }\n",
+    "create_animation(rf_dict=translation_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9960a942",
+   "metadata": {},
+   "source": [
+    "Using the reference frame-objects, the trajectory of any point in that frame can easily be extracted.\n",
+    "\n",
+    "For the case of a Translation object, this results in the original trajectory but shifted in space.\n",
+    "Here, we extract the trajectory of the origin $\\mathbf{x}_L=(0, 0, 0)^T$ and point $\\mathbf{x}_L=(1, 1, 1)^T$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4551a6f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trs = ( [rf.trajectory((0., 0., 0.)) for rf in translation_dict.values()]\n",
+    "       + [rf.trajectory((1., 1., 1.)) for rf in translation_dict.values()] )\n",
+    "\n",
+    "create_animation(traj_list=trs, rf_dict=translation_dict)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc88b396",
+   "metadata": {},
+   "source": [
+    "### Rotation\n",
+    "\n",
+    "Local Reference Frame that rotates around some axis at a constant rate.\n",
+    "\n",
+    "It is defined by the rate of rotation (in revolutions per second) and the axis the points revolve around (`'x'`, `'y'` or `'z'`).\n",
+    "\n",
+    "If required, an additional constant shift of the origin can be provided as `origin`.\n",
+    "\n",
+    "Similar to `Translation`, a constant rotation around Euler angles can be applied. \n",
+    "This rotation is applied after the rotation due to the revolutions, but before the constant shift is applied.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd414beb",
+   "metadata": {},
+   "source": [
+    "#### Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "245dd8cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rot1 = Rotation(1, orientation_angles=(45, 0, 0), origin=(-5, -3, 4), axis='z')\n",
+    "rot2 = Rotation(1.2, orientation_angles=(0, 0, 0), origin=(0, 0, 5), axis='y')\n",
+    "\n",
+    "rf_dict={'r1': rot1, 'r2': rot2,}\n",
+    "\n",
+    "create_animation(rf_dict=rf_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e52622",
+   "metadata": {},
+   "source": [
+    "\n",
+    "##### Rotor in Wind Tunnel Coordinate System\n",
+    "\n",
+    "It is assumed that the $x$-Axis of the global system is in the direction of the\n",
+    "horizontal flow, $y$ is also horizontal and $z$ is vertical.\n",
+    "\n",
+    "If the points will be provided as a $xy$-grid (e.g. `StationaryGrid`) and we want\n",
+    "to have a calculation grid in the rotor plane (perpendicular to flow), we need to\n",
+    "map the local $x$-axis to the global $y$-axis, and the local $y$-axis to the global\n",
+    "$z$-axis. This is achieved by first applying a 90° rotation around the\n",
+    "$x$-axis followed by 90° rotation around the global $z$-axis.\n",
+    "\n",
+    "The local axis of rotation is the z-axis.\n",
+    "\n",
+    "Here `origin=(5.,0.,0.)` denotes the position $(0,0)^T$ gets mapped to,\n",
+    "i.e. that the rotor has an axial position of 5m."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a0a74b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotor_frame = Rotation(0.5, orientation_angles=(90, 0, 90), origin=(5., 0., 0.), axis='z')\n",
+    "\n",
+    "trs = [rotor_frame.trajectory((x, y, 0.)) for x in np.arange(-8, 9, step=4) for y in np.arange(-8, 9, step=4)]\n",
+    "\n",
+    "create_animation(traj_list=trs, rf_dict={'rotor': rotor_frame})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/forot_demo.ipynb
+++ b/scripts/forot_demo.ipynb
@@ -7,32 +7,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from abc import ABC, abstractmethod\n",
-    "from typing import Self\n",
-    "from copy import deepcopy\n",
     "import itertools\n",
-    "\n",
-    "import numpy as np\n",
-    "from numpy.typing import NDArray, ArrayLike\n",
-    "# scipy >= 1.16\n",
-    "from scipy.spatial.transform import RigidTransform, Rotation as ScipyRotation\n",
-    "from scipy.interpolate import make_interp_spline\n",
     "\n",
     "import matplotlib.animation\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "from scene_synthesis import UniformLinearTrajectory, SplineTrajectory, CircularTrajectory\n",
-    "from scene_synthesis import Translation, Rotation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5cc46d29",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib notebook"
+    "import numpy as np\n",
+    "from scene_synthesis import CircularTrajectory, Rotation, SplineTrajectory, Translation, UniformLinearTrajectory"
    ]
   },
   {
@@ -92,8 +72,8 @@
     "\n",
     "colors = (\"#FF6666\", \"#005533\", \"#1199EE\")  # Colorblind-safe RGB\n",
     "\n",
-    "def prepare_plot(ax):\n",
-    "    for axis, c in zip((ax.xaxis, ax.yaxis, ax.zaxis), colors):\n",
+    "def prepare_plot(ax):  # noqa: D103\n",
+    "    for axis, c in zip((ax.xaxis, ax.yaxis, ax.zaxis), colors):  # noqa: B905\n",
     "        axlabel = axis.axis_name\n",
     "        axis.set_label_text(axlabel)\n",
     "        axis.label.set_color(c)\n",
@@ -104,7 +84,7 @@
     "        ax.set(ylim3d=(-5, 15))\n",
     "        ax.set(zlim3d=(-10, 10))\n",
     "\n",
-    "def plot_trajectory(ax, traj, c='black'):\n",
+    "def plot_trajectory(ax, traj, c='black'):  # noqa: D103\n",
     "\n",
     "        all_xpos = traj.location(all_times)\n",
     "\n",
@@ -116,12 +96,12 @@
     "            velocity = traj.velocity(t) / 5\n",
     "            ax.scatter(*location, marker='o', color=c)\n",
     "\n",
-    "            ax.plot(*zip(location, location+velocity), lw=2, color='grey')\n",
+    "            ax.plot(*zip(location, location+velocity), lw=2, color='grey')  # noqa: B905\n",
     "\n",
     "        return plotter\n",
     "\n",
     "\n",
-    "def plot_reference_frame(ax, ref_frame, name, scale=1):\n",
+    "def plot_reference_frame(ax, ref_frame, name, scale=1):  # noqa: D103\n",
     "\n",
     "    #loc = np.array([t, t])\n",
     "    def plotter(tf_t):\n",
@@ -139,18 +119,17 @@
     "                    bbox={\"fc\": \"w\", \"alpha\": 0.8, \"boxstyle\": \"circle\"})\n",
     "    return plotter\n",
     "\n",
-    "def create_animation(traj_list=None, rf_dict=None):\n",
+    "def create_animation(traj_list=None, rf_dict=None):  # noqa: D103\n",
     "\n",
-    "    traj_list = traj_list if traj_list is not None else list()\n",
-    "    rf_dict = rf_dict if rf_dict is not None else dict()\n",
+    "    traj_list = traj_list if traj_list is not None else []\n",
+    "    rf_dict = rf_dict if rf_dict is not None else {}\n",
     "\n",
-    "    N = 100\n",
     "    t_interval=(-1, 2)\n",
     "    colors = plt.cm.tab10.colors\n",
     "\n",
     "    fig, ax = plt.subplots(subplot_kw={\"projection\": \"3d\"})\n",
     "\n",
-    "    all_times = np.linspace(*t_interval, N)\n",
+    "    all_times = np.linspace(*t_interval, 100)\n",
     "    line_plotter = [plot_trajectory(ax, tr, c) for tr, c in zip(traj_list, itertools.cycle(colors))]\n",
     "    rf_plotter = [plot_reference_frame(ax, rf, name, 5) for name, rf in rf_dict.items()]\n",
     "\n",
@@ -163,8 +142,9 @@
     "        [plotter(t) for plotter in rf_plotter]\n",
     "\n",
     "\n",
-    "    return matplotlib.animation.FuncAnimation(fig, animate, frames=all_times, interval=(all_times[1]-all_times[0]) * 1000)\n",
-    "    #return animate"
+    "    return matplotlib.animation.FuncAnimation(\n",
+    "        fig, animate, frames=all_times, interval=(all_times[1]-all_times[0]) * 1000\n",
+    "    )"
    ]
   },
   {
@@ -425,7 +405,7 @@
     "rot1 = Rotation(1, orientation_angles=(45, 0, 0), origin=(-5, -3, 4), axis='z')\n",
     "rot2 = Rotation(1.2, orientation_angles=(0, 0, 0), origin=(0, 0, 5), axis='y')\n",
     "\n",
-    "rf_dict={'r1': rot1, 'r2': rot2,}\n",
+    "rf_dict={'r1': rot1, 'r2': rot2}\n",
     "\n",
     "create_animation(rf_dict=rf_dict)"
    ]

--- a/scripts/forot_demo.ipynb
+++ b/scripts/forot_demo.ipynb
@@ -61,16 +61,17 @@
     "# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n",
     "# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n",
     "# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n",
-    "plt.rcParams[\"animation.html\"] = \"jshtml\"\n",
+    "plt.rcParams['animation.html'] = 'jshtml'\n",
     "plt.rcParams['figure.dpi'] = 150\n",
     "plt.ioff()\n",
     "\n",
     "N = 50\n",
-    "t_interval=(-1, 2)\n",
+    "t_interval = (-1, 2)\n",
     "\n",
     "all_times = np.linspace(*t_interval, N)\n",
     "\n",
-    "colors = (\"#FF6666\", \"#005533\", \"#1199EE\")  # Colorblind-safe RGB\n",
+    "colors = ('#FF6666', '#005533', '#1199EE')  # Colorblind-safe RGB\n",
+    "\n",
     "\n",
     "def prepare_plot(ax):  # noqa: D103\n",
     "    for axis, c in zip((ax.xaxis, ax.yaxis, ax.zaxis), colors):  # noqa: B905\n",
@@ -84,26 +85,27 @@
     "        ax.set(ylim3d=(-5, 15))\n",
     "        ax.set(zlim3d=(-10, 10))\n",
     "\n",
+    "\n",
     "def plot_trajectory(ax, traj, c='black'):  # noqa: D103\n",
     "\n",
-    "        all_xpos = traj.location(all_times)\n",
+    "    all_xpos = traj.location(all_times)\n",
     "\n",
-    "        def plotter(t):\n",
-    "            ax.plot(*all_xpos, color=c, lw=0.5)\n",
-    "            #ax.plot(xs=all_xpos[:,0], ys=all_xpos[:,1], zs=all_xpos[:,2], c, lw=0.5)\n",
+    "    def plotter(t):\n",
+    "        ax.plot(*all_xpos, color=c, lw=0.5)\n",
+    "        # ax.plot(xs=all_xpos[:,0], ys=all_xpos[:,1], zs=all_xpos[:,2], c, lw=0.5)\n",
     "\n",
-    "            location = traj.location(t)\n",
-    "            velocity = traj.velocity(t) / 5\n",
-    "            ax.scatter(*location, marker='o', color=c)\n",
+    "        location = traj.location(t)\n",
+    "        velocity = traj.velocity(t) / 5\n",
+    "        ax.scatter(*location, marker='o', color=c)\n",
     "\n",
-    "            ax.plot(*zip(location, location+velocity), lw=2, color='grey')  # noqa: B905\n",
+    "        ax.plot(*zip(location, location + velocity), lw=2, color='grey')  # noqa: B905\n",
     "\n",
-    "        return plotter\n",
+    "    return plotter\n",
     "\n",
     "\n",
     "def plot_reference_frame(ax, ref_frame, name, scale=1):  # noqa: D103\n",
     "\n",
-    "    #loc = np.array([t, t])\n",
+    "    # loc = np.array([t, t])\n",
     "    def plotter(tf_t):\n",
     "\n",
     "        tf = ref_frame.rigid_transform(tf_t)\n",
@@ -113,21 +115,24 @@
     "            line = np.zeros((2, 3))\n",
     "            line[1, i] = scale\n",
     "            line_rot = tf.apply(line)\n",
-    "            line_plot = line_rot #+ loc\n",
+    "            line_plot = line_rot  # + loc\n",
     "            ax.plot(line_plot[:, 0], line_plot[:, 1], line_plot[:, 2], c)\n",
-    "            ax.text(*tf_t, s=name, color=\"k\", va=\"center\", ha=\"center\",\n",
-    "                    bbox={\"fc\": \"w\", \"alpha\": 0.8, \"boxstyle\": \"circle\"})\n",
+    "            ax.text(\n",
+    "                *tf_t, s=name, color='k', va='center', ha='center', bbox={'fc': 'w', 'alpha': 0.8, 'boxstyle': 'circle'}\n",
+    "            )\n",
+    "\n",
     "    return plotter\n",
+    "\n",
     "\n",
     "def create_animation(traj_list=None, rf_dict=None):  # noqa: D103\n",
     "\n",
     "    traj_list = traj_list if traj_list is not None else []\n",
     "    rf_dict = rf_dict if rf_dict is not None else {}\n",
     "\n",
-    "    t_interval=(-1, 2)\n",
+    "    t_interval = (-1, 2)\n",
     "    colors = plt.cm.tab10.colors\n",
     "\n",
-    "    fig, ax = plt.subplots(subplot_kw={\"projection\": \"3d\"})\n",
+    "    fig, ax = plt.subplots(subplot_kw={'projection': '3d'})\n",
     "\n",
     "    all_times = np.linspace(*t_interval, 100)\n",
     "    line_plotter = [plot_trajectory(ax, tr, c) for tr, c in zip(traj_list, itertools.cycle(colors))]\n",
@@ -141,9 +146,8 @@
     "        [plotter(t) for plotter in line_plotter]\n",
     "        [plotter(t) for plotter in rf_plotter]\n",
     "\n",
-    "\n",
     "    return matplotlib.animation.FuncAnimation(\n",
-    "        fig, animate, frames=all_times, interval=(all_times[1]-all_times[0]) * 1000\n",
+    "        fig, animate, frames=all_times, interval=(all_times[1] - all_times[0]) * 1000\n",
     "    )"
    ]
   },
@@ -204,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ult = UniformLinearTrajectory(x0=(0.,5.,0.), v0=(5.,0.,0.))"
+    "ult = UniformLinearTrajectory(x0=(0.0, 5.0, 0.0), v0=(5.0, 0.0, 0.0))"
    ]
   },
   {
@@ -244,8 +248,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ct1 = CircularTrajectory(ref_pos=(0.,0.,0), rev_per_sec=1., axis_dir=(1.,0.,0), fixpoint=(0.,0.,5.))\n",
-    "ct2 = CircularTrajectory(ref_pos=(5.,0.,0.), rev_per_sec=1., axis_dir=(1.,1.,1.), fixpoint=(0.,0.,0.))"
+    "ct1 = CircularTrajectory(ref_pos=(0.0, 0.0, 0), rev_per_sec=1.0, axis_dir=(1.0, 0.0, 0), fixpoint=(0.0, 0.0, 5.0))\n",
+    "ct2 = CircularTrajectory(ref_pos=(5.0, 0.0, 0.0), rev_per_sec=1.0, axis_dir=(1.0, 1.0, 1.0), fixpoint=(0.0, 0.0, 0.0))"
    ]
   },
   {
@@ -334,15 +338,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "translation_ult = Translation(origin_traj=ult, orientation_angles=(0,0,45))\n",
-    "translation_sp = Translation(origin_traj=spt, orientation_angles=[90,0,90])\n",
-    "translation_ct = Translation(origin_traj=ct2, orientation_angles=[0,0,0])\n",
+    "translation_ult = Translation(origin_traj=ult, orientation_angles=(0, 0, 45))\n",
+    "translation_sp = Translation(origin_traj=spt, orientation_angles=[90, 0, 90])\n",
+    "translation_ct = Translation(origin_traj=ct2, orientation_angles=[0, 0, 0])\n",
     "\n",
     "translation_dict = {\n",
-    "        'ult': translation_ult,\n",
-    "        'sp': translation_sp,\n",
-    "        'ct': translation_ct,\n",
-    "    }\n",
+    "    'ult': translation_ult,\n",
+    "    'sp': translation_sp,\n",
+    "    'ct': translation_ct,\n",
+    "}\n",
     "create_animation(rf_dict=translation_dict)"
    ]
   },
@@ -364,10 +368,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trs = ( [rf.trajectory((0., 0., 0.)) for rf in translation_dict.values()]\n",
-    "       + [rf.trajectory((1., 1., 1.)) for rf in translation_dict.values()] )\n",
+    "trs = [rf.trajectory((0.0, 0.0, 0.0)) for rf in translation_dict.values()] + [\n",
+    "    rf.trajectory((1.0, 1.0, 1.0)) for rf in translation_dict.values()\n",
+    "]\n",
     "\n",
-    "create_animation(traj_list=trs, rf_dict=translation_dict)\n"
+    "create_animation(traj_list=trs, rf_dict=translation_dict)"
    ]
   },
   {
@@ -405,7 +410,7 @@
     "rot1 = Rotation(1, orientation_angles=(45, 0, 0), origin=(-5, -3, 4), axis='z')\n",
     "rot2 = Rotation(1.2, orientation_angles=(0, 0, 0), origin=(0, 0, 5), axis='y')\n",
     "\n",
-    "rf_dict={'r1': rot1, 'r2': rot2}\n",
+    "rf_dict = {'r1': rot1, 'r2': rot2}\n",
     "\n",
     "create_animation(rf_dict=rf_dict)"
    ]
@@ -440,9 +445,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rotor_frame = Rotation(0.5, orientation_angles=(90, 0, 90), origin=(5., 0., 0.), axis='z')\n",
+    "rotor_frame = Rotation(0.5, orientation_angles=(90, 0, 90), origin=(5.0, 0.0, 0.0), axis='z')\n",
     "\n",
-    "trs = [rotor_frame.trajectory((x, y, 0.)) for x in np.arange(-8, 9, step=4) for y in np.arange(-8, 9, step=4)]\n",
+    "trs = [rotor_frame.trajectory((x, y, 0.0)) for x in np.arange(-8, 9, step=4) for y in np.arange(-8, 9, step=4)]\n",
     "\n",
     "create_animation(traj_list=trs, rf_dict={'rotor': rotor_frame})"
    ]

--- a/src/scene_synthesis/__init__.py
+++ b/src/scene_synthesis/__init__.py
@@ -6,3 +6,5 @@ from .environments import Environment as Environment
 from .microphones import Microphone as Microphone
 from .scene import Scene as Scene
 from .sources import Source as Source
+from .trajectory import CircularTrajectory, SplineTrajectory, UniformLinearTrajectory
+from .forot import Rotation, Translation

--- a/src/scene_synthesis/__init__.py
+++ b/src/scene_synthesis/__init__.py
@@ -3,8 +3,11 @@
 from .directivities import CardioidDirectivity as CardioidDirectivity
 from .directivities import OmniDirectivity as OmniDirectivity
 from .environments import Environment as Environment
+from .forot import Rotation as Rotation
+from .forot import Translation as Translation
 from .microphones import Microphone as Microphone
 from .scene import Scene as Scene
 from .sources import Source as Source
-from .trajectory import CircularTrajectory, SplineTrajectory, UniformLinearTrajectory
-from .forot import Rotation, Translation
+from .trajectory import CircularTrajectory as CircularTrajectory
+from .trajectory import SplineTrajectory as SplineTrajectory
+from .trajectory import UniformLinearTrajectory as UniformLinearTrajectory

--- a/src/scene_synthesis/forot.py
+++ b/src/scene_synthesis/forot.py
@@ -1,4 +1,5 @@
 """Frame of Reference over Time."""
+
 from abc import ABC, abstractmethod
 from typing import override
 
@@ -46,9 +47,7 @@ class Translation(FOROT):
         orientation_angles: ArrayLike = (0.0, 0.0, 0.0),
     ):
         self.origin_traj = origin_traj
-        self.orientation = ScipyRotation.from_euler(
-            'xyz', orientation_angles, degrees=True
-        )
+        self.orientation = ScipyRotation.from_euler('xyz', orientation_angles, degrees=True)
 
     @override
     def trajectory(self, x_local: ArrayLike) -> Trajectory:
@@ -76,23 +75,17 @@ class Rotation(FOROT):
         The axis around which to rotate.
     """
 
-    base = {
-        'x': np.array([1., 0., 0.]),
-        'y': np.array([0., 1., 0.]),
-        'z': np.array([0., 0., 1.])
-    }
+    base = {'x': np.array([1.0, 0.0, 0.0]), 'y': np.array([0.0, 1.0, 0.0]), 'z': np.array([0.0, 0.0, 1.0])}
 
     def __init__(
         self,
-        rev_per_sec: float=1.,
-        orientation_angles: ArrayLike=(0.,0.,0.),
-        origin: ArrayLike=(0.,0.,0.),
-        axis: str='z'
+        rev_per_sec: float = 1.0,
+        orientation_angles: ArrayLike = (0.0, 0.0, 0.0),
+        origin: ArrayLike = (0.0, 0.0, 0.0),
+        axis: str = 'z',
     ):
         self.origin = np.asarray(origin)
-        self.const_rotation = ScipyRotation.from_euler(
-            'xyz', orientation_angles, degrees=True
-        )
+        self.const_rotation = ScipyRotation.from_euler('xyz', orientation_angles, degrees=True)
         self.rev_per_sec = rev_per_sec
         self.axis = self.base[axis]
 
@@ -102,12 +95,11 @@ class Rotation(FOROT):
             self.rev_per_sec,
             self.origin + self.const_rotation.apply(x_local),
             self.const_rotation.apply(self.axis),
-            self.origin
+            self.origin,
         )
 
     @override
     def rigid_transform(self, t: float) -> RigidTransform:
         return RigidTransform.from_components(
-            self.origin,
-            self.const_rotation * ScipyRotation.from_rotvec(t * self.rev_per_sec * 2 * np.pi * self.axis)
+            self.origin, self.const_rotation * ScipyRotation.from_rotvec(t * self.rev_per_sec * 2 * np.pi * self.axis)
         )

--- a/src/scene_synthesis/forot.py
+++ b/src/scene_synthesis/forot.py
@@ -1,0 +1,117 @@
+"""Frame of Reference over Time."""
+from abc import ABC, abstractmethod
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.spatial.transform import RigidTransform
+from scipy.spatial.transform import Rotation as ScipyRotation
+
+from .trajectory import CircularTrajectory, Trajectory
+
+
+class FOROT(ABC):
+    """Representation of a Local Reference Frame.
+
+    Typically this would be the body-fixed reference frame of the moving
+    source region (e.g. aircraft).
+    """
+
+    @abstractmethod
+    def trajectory(self, x_local: ArrayLike) -> Trajectory: ...
+
+    @abstractmethod
+    def rigid_transform(self, t: float) -> RigidTransform: ...
+
+
+class Translation(FOROT):
+    """Local Reference Frame where the Orientation is constant.
+
+    Parameters
+    ----------
+    origin_traj: Trajectory
+        The trajectory of the origin of the local reference frame.
+    orientation: np.ndarray
+        'xyz'-Euler angles in degrees of a rotation that is applied to the
+        reference frame after the shift due to translation.
+    """
+
+    def __init__(
+        self,
+        origin_traj: Trajectory,
+        orientation_angles: ArrayLike = (0.0, 0.0, 0.0),
+    ):
+        self.origin_traj = origin_traj
+        self.orientation = ScipyRotation.from_euler(
+            'xyz', orientation_angles, degrees=True
+        )
+
+    def trajectory(self, x_local: ArrayLike) -> Trajectory:
+        shift = self.orientation.apply(x_local)
+        return self.origin_traj.shift_by_offset(shift)
+
+    def rigid_transform(self, t: float) -> RigidTransform:
+        return RigidTransform.from_components(self.origin_traj.location(t), self.orientation)
+
+    def partial_time_derivative(self, x_local: ArrayLike, t: float) -> NDArray:
+        # Derivative is independent of location in space.
+        return self.origin_traj.location(t, der=1)
+
+
+class Rotation(FOROT):
+    """Local Reference Frame that rotates around some axis at a constant rate.
+
+    Parameters
+    ----------
+    rev_per_sec: float
+        Rate of rotation (in revolutions per second).
+    orientation: np.ndarray, optional
+        'xyz'-Euler angles in degrees of a rotation that is applied to the
+        reference frame after the shift due to translation.
+        This rotation is applied after the rotation around `axis` but before the
+        shift due to `origin`
+    axis: {x, y, z}, optional
+        The axis around which to rotate.
+    """
+
+    base = {
+        'x': np.array([1., 0., 0.]),
+        'y': np.array([0., 1., 0.]),
+        'z': np.array([0., 0., 1.])
+    }
+
+    def __init__(
+        self,
+        rev_per_sec: float=1.,
+        orientation_angles: ArrayLike=(0.,0.,0.),
+        origin: ArrayLike=(0.,0.,0.),
+        axis: str='z'
+    ):
+        self.origin = np.asarray(origin)
+        self.const_rotation = ScipyRotation.from_euler(
+            'xyz', orientation_angles, degrees=True
+        )
+        self.rev_per_sec = rev_per_sec
+        self.axis = self.base[axis]
+
+    def trajectory(self, x_local: ArrayLike) -> CircularTrajectory:
+        return CircularTrajectory(
+            self.rev_per_sec,
+            self.origin + self.const_rotation.apply(x_local),
+            self.const_rotation.apply(self.axis),
+            self.origin
+        )
+
+    def rigid_transform(self, t: float) -> RigidTransform:
+        return RigidTransform.from_components(
+            self.origin,
+            self.const_rotation * ScipyRotation.from_rotvec(t * self.rev_per_sec * 2 * np.pi * self.axis)
+        )
+
+    def partial_time_derivative(self, x_local: ArrayLike, t: float) -> NDArray:
+        # Derivative is 90° rotation from orignal location, without any translation
+        # Note: Untested!
+        omega = self.rev_per_sec * 2 * np.pi
+
+        rot = ScipyRotation.from_rotvec(t * omega + np.pi / 2 * self.axis)
+
+        return omega * self.const_rotation.apply(rot.apply(x_local))

--- a/src/scene_synthesis/forot.py
+++ b/src/scene_synthesis/forot.py
@@ -1,8 +1,9 @@
 """Frame of Reference over Time."""
 from abc import ABC, abstractmethod
+from typing import override
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from scipy.spatial.transform import RigidTransform
 from scipy.spatial.transform import Rotation as ScipyRotation
 
@@ -17,10 +18,14 @@ class FOROT(ABC):
     """
 
     @abstractmethod
-    def trajectory(self, x_local: ArrayLike) -> Trajectory: ...
+    def trajectory(self, x_local: ArrayLike) -> Trajectory:
+        """Get Trajectory of Point in this Reference Frame."""
+        ...
 
     @abstractmethod
-    def rigid_transform(self, t: float) -> RigidTransform: ...
+    def rigid_transform(self, t: float) -> RigidTransform:
+        """Get Spatial Transorm of this Reference Frame at time t."""
+        ...
 
 
 class Translation(FOROT):
@@ -45,16 +50,14 @@ class Translation(FOROT):
             'xyz', orientation_angles, degrees=True
         )
 
+    @override
     def trajectory(self, x_local: ArrayLike) -> Trajectory:
         shift = self.orientation.apply(x_local)
         return self.origin_traj.shift_by_offset(shift)
 
+    @override
     def rigid_transform(self, t: float) -> RigidTransform:
         return RigidTransform.from_components(self.origin_traj.location(t), self.orientation)
-
-    def partial_time_derivative(self, x_local: ArrayLike, t: float) -> NDArray:
-        # Derivative is independent of location in space.
-        return self.origin_traj.location(t, der=1)
 
 
 class Rotation(FOROT):
@@ -93,6 +96,7 @@ class Rotation(FOROT):
         self.rev_per_sec = rev_per_sec
         self.axis = self.base[axis]
 
+    @override
     def trajectory(self, x_local: ArrayLike) -> CircularTrajectory:
         return CircularTrajectory(
             self.rev_per_sec,
@@ -101,17 +105,9 @@ class Rotation(FOROT):
             self.origin
         )
 
+    @override
     def rigid_transform(self, t: float) -> RigidTransform:
         return RigidTransform.from_components(
             self.origin,
             self.const_rotation * ScipyRotation.from_rotvec(t * self.rev_per_sec * 2 * np.pi * self.axis)
         )
-
-    def partial_time_derivative(self, x_local: ArrayLike, t: float) -> NDArray:
-        # Derivative is 90° rotation from orignal location, without any translation
-        # Note: Untested!
-        omega = self.rev_per_sec * 2 * np.pi
-
-        rot = ScipyRotation.from_rotvec(t * omega + np.pi / 2 * self.axis)
-
-        return omega * self.const_rotation.apply(rot.apply(x_local))

--- a/src/scene_synthesis/trajectory.py
+++ b/src/scene_synthesis/trajectory.py
@@ -1,7 +1,7 @@
 """Frame of Reference over Time."""
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Self
+from typing import Self, override
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -48,18 +48,21 @@ class UniformLinearTrajectory(Trajectory):
         self.x0 = np.asarray(x0)
         self.v0 = np.asarray(v0)
 
+    @override
     def location(self, t):
         t = np.asarray(t)
         if t.ndim == 0:
             return self.x0 + t * self.v0
         return self.x0[:, np.newaxis] + t.flatten() * self.v0[:, np.newaxis]
 
+    @override
     def velocity(self, t):
         t = np.asarray(t)
         if t.ndim == 0:
             return self.v0
         return np.broadcast_to(self.v0, t.size + (3,)).T
 
+    @override
     def shift_by_offset(self, x_off):
         return UniformLinearTrajectory(self.x0 + x_off, self.v0)
 
@@ -70,13 +73,16 @@ class SplineTrajectory(Trajectory):
     def __init__(self, times, positions, *args, **kwargs):
         self._bspline_obj = make_interp_spline(times, positions, *args, **kwargs)
 
+    @override
     def location(self, t):
         return self._bspline_obj(t, nu=0).T
 
+    @override
     def velocity(self, t):
         return self._bspline_obj(t, nu=1).T
 
 
+    @override
     def shift_by_offset(self, x_off):
         cp = deepcopy(self)
         cp._bspline_obj.c += x_off
@@ -126,6 +132,7 @@ class CircularTrajectory(Trajectory):
         self._xc = ref_pos - self._center_point
         self._xs = np.cross(axis_dir, self._xc)
 
+    @override
     def location(self, t):
         t = np.asarray(t)
         omega = self.rev_per_sec * 2 * np.pi
@@ -138,6 +145,7 @@ class CircularTrajectory(Trajectory):
              + self._xs[:, np.newaxis] * np.sin(omega * t)
         )
 
+    @override
     def velocity(self, t):
         t = np.asarray(t)
         omega = self.rev_per_sec * 2 * np.pi
@@ -149,6 +157,7 @@ class CircularTrajectory(Trajectory):
              + self._xs[:, np.newaxis] * np.cos(omega * t)
         )
 
+    @override
     def shift_by_offset(self, x_off):
         cp = deepcopy(self)
         cp._center_point += x_off

--- a/src/scene_synthesis/trajectory.py
+++ b/src/scene_synthesis/trajectory.py
@@ -1,0 +1,155 @@
+"""Frame of Reference over Time."""
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Self
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.interpolate import make_interp_spline
+
+
+class Trajectory(ABC):
+    """Representation of a Trajectory."""
+
+    @abstractmethod
+    def location(self, t: ArrayLike) -> NDArray:
+        """Location over time.
+
+        Result hase shape ``(3,)`` for scalar values times and ``(3,N)`` for
+        array-valued times.
+        """
+        ...
+
+    @abstractmethod
+    def velocity(self, t: ArrayLike) -> NDArray:
+        """Velocity over time.
+
+        Implementing Base Class must guarantee correctness.
+        """
+        ...
+
+    @abstractmethod
+    def shift_by_offset(self, x_off: ArrayLike) -> Self:
+        """Return a copy of this trajectory shifted in space by some const. 3D-offset."""
+        ...
+
+class UniformLinearTrajectory(Trajectory):
+    """Motion with constant speed."""
+
+    def __init__(self, x0: ArrayLike, v0: ArrayLike):
+        """
+        Parameters
+        ----------
+        x0 : ArrayLike of shape (3,)
+            Position at t=0.
+        v0 : ArrayLike of shape (3,)
+            Velocity.
+        """  # noqa: D205
+        self.x0 = np.asarray(x0)
+        self.v0 = np.asarray(v0)
+
+    def location(self, t):
+        t = np.asarray(t)
+        if t.ndim == 0:
+            return self.x0 + t * self.v0
+        return self.x0[:, np.newaxis] + t.flatten() * self.v0[:, np.newaxis]
+
+    def velocity(self, t):
+        t = np.asarray(t)
+        if t.ndim == 0:
+            return self.v0
+        return np.broadcast_to(self.v0, t.size + (3,)).T
+
+    def shift_by_offset(self, x_off):
+        return UniformLinearTrajectory(self.x0 + x_off, self.v0)
+
+
+class SplineTrajectory(Trajectory):
+    """Motion defined by some spline interpolation."""
+
+    def __init__(self, times, positions, *args, **kwargs):
+        self._bspline_obj = make_interp_spline(times, positions, *args, **kwargs)
+
+    def location(self, t):
+        return self._bspline_obj(t, nu=0).T
+
+    def velocity(self, t):
+        return self._bspline_obj(t, nu=1).T
+
+
+    def shift_by_offset(self, x_off):
+        cp = deepcopy(self)
+        cp._bspline_obj.c += x_off
+        return cp
+
+
+class CircularTrajectory(Trajectory):
+    """Represents a circular motion of a point around some center.
+
+    Does so by storing a centerpoint `_center_point`, a vector from the center
+    point to the initial point `_xc` and a vector perpendicular to both the
+    axis of rotation and `_xc`.
+
+    The location is calculated as the sum of the center point, the cosine-weighted
+    `_xc` and the sine-weighted `_xs`.
+    """
+
+    def __init__(
+        self,
+        rev_per_sec: float,
+        ref_pos: ArrayLike,
+        axis_dir: ArrayLike = (0.0, 0.0, 1.0),
+        fixpoint: ArrayLike = (0.0, 0.0, 0.0),
+    ):
+        """
+        Parameters
+        ----------
+        ref_pos : ArrayLike of shape (3,)
+            Position at t=0
+        rev_per_sec : float
+            Speed of rotation in revolutions per second
+        axis_dir : ArrayLike of shape (3,), optional
+            The direction of the axis of rotation.
+            Will be normalized. Must have length > 0.
+        fixpoint : ArrayLike of shape (3,), optional
+            A point on the axis of rotation.
+        """  # noqa: D205
+        self.rev_per_sec = rev_per_sec
+
+        ref_pos = np.asarray(ref_pos)
+        fixpoint = np.asarray(fixpoint)
+
+        axis_dir = np.asarray(axis_dir) / np.linalg.norm(axis_dir)
+        dx = ref_pos - fixpoint
+
+        self._center_point = fixpoint + axis_dir * np.dot(axis_dir, dx)
+        self._xc = ref_pos - self._center_point
+        self._xs = np.cross(axis_dir, self._xc)
+
+    def location(self, t):
+        t = np.asarray(t)
+        omega = self.rev_per_sec * 2 * np.pi
+        if t.ndim == 0:
+            return self._center_point + self._xc * np.cos(omega * t) + self._xs * np.sin(omega * t)
+        t = t.flatten()
+        return (
+            self._center_point[:, np.newaxis]
+             + self._xc[:, np.newaxis] * np.cos(omega * t)
+             + self._xs[:, np.newaxis] * np.sin(omega * t)
+        )
+
+    def velocity(self, t):
+        t = np.asarray(t)
+        omega = self.rev_per_sec * 2 * np.pi
+        if t.ndim == 0:
+            return omega * ( - self._xc * np.sin(omega * t) + self._xs * np.cos(omega * t))
+        t = t.flatten()
+        return omega * (
+             - self._xc[:, np.newaxis] * np.sin(omega * t)
+             + self._xs[:, np.newaxis] * np.cos(omega * t)
+        )
+
+    def shift_by_offset(self, x_off):
+        cp = deepcopy(self)
+        cp._center_point += x_off
+        return cp

--- a/src/scene_synthesis/trajectory.py
+++ b/src/scene_synthesis/trajectory.py
@@ -1,4 +1,5 @@
 """Frame of Reference over Time."""
+
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Self, override
@@ -32,6 +33,7 @@ class Trajectory(ABC):
     def shift_by_offset(self, x_off: ArrayLike) -> Self:
         """Return a copy of this trajectory shifted in space by some const. 3D-offset."""
         ...
+
 
 class UniformLinearTrajectory(Trajectory):
     """Motion with constant speed."""
@@ -80,7 +82,6 @@ class SplineTrajectory(Trajectory):
     @override
     def velocity(self, t):
         return self._bspline_obj(t, nu=1).T
-
 
     @override
     def shift_by_offset(self, x_off):
@@ -141,8 +142,8 @@ class CircularTrajectory(Trajectory):
         t = t.flatten()
         return (
             self._center_point[:, np.newaxis]
-             + self._xc[:, np.newaxis] * np.cos(omega * t)
-             + self._xs[:, np.newaxis] * np.sin(omega * t)
+            + self._xc[:, np.newaxis] * np.cos(omega * t)
+            + self._xs[:, np.newaxis] * np.sin(omega * t)
         )
 
     @override
@@ -150,12 +151,9 @@ class CircularTrajectory(Trajectory):
         t = np.asarray(t)
         omega = self.rev_per_sec * 2 * np.pi
         if t.ndim == 0:
-            return omega * ( - self._xc * np.sin(omega * t) + self._xs * np.cos(omega * t))
+            return omega * (-self._xc * np.sin(omega * t) + self._xs * np.cos(omega * t))
         t = t.flatten()
-        return omega * (
-             - self._xc[:, np.newaxis] * np.sin(omega * t)
-             + self._xs[:, np.newaxis] * np.cos(omega * t)
-        )
+        return omega * (-self._xc[:, np.newaxis] * np.sin(omega * t) + self._xs[:, np.newaxis] * np.cos(omega * t))
 
     @override
     def shift_by_offset(self, x_off):


### PR DESCRIPTION
As discussed in #5 this Pull Request introduces a Frame of Reference Class (FOROT).
It follows somewhat closely the Notebook that I had uploaded there.

As documentation I added that notebook, updated so it imports the classes from scene-synthesis.
I kept it as a notebook, due to the much nicer formatting ang displaying of the animated plots.


### Possible ToDo's

The class hierarchy uses *abstract base classes* and is not based on the *Traits* package.

--- 

Note that I have added a `Trajectory` class in `trajectory.py`, which is required for the `FOROT` classes to work. It does clash with the unmerged pull request #41 which also defines a `Trajectory` class. 

If that pull request is merged, this PR can be amended so it uses that other `Trajectory` class. It should be somewhat straight forward, as I made sure to use the same method names for `Trajectory.location(...)` and `Trajectory.velocity(...)`. 

However, this implementation requires the trajectories to be shifted by some constant offset (`Trajectory.shift_by_offset(...)`