### PR TITLE
1st order directivity

### DIFF
--- a/src/scene_synthesis/__init__.py
+++ b/src/scene_synthesis/__init__.py
@@ -5,4 +5,6 @@ from .directivities import OmniDirectivity as OmniDirectivity
 from .environments import Environment as Environment
 from .microphones import Microphone as Microphone
 from .scene import Scene as Scene
+from .sources import DipoleSource as DipoleSource
+from .sources import MonopoleSource as MonopoleSource
 from .sources import Source as Source

--- a/src/scene_synthesis/environments.py
+++ b/src/scene_synthesis/environments.py
@@ -42,6 +42,9 @@ class Environment(HasStrictTraits):
     #: Speed of sound in the environment.
     c = Float(343.0)
 
+    #: Ambient density of the medium.
+    rho0 = Float(1.2041)
+
     #: Region of interest for calculations. Reserved for future use.
     roi = Union(None, CArray)
 

--- a/src/scene_synthesis/scene.py
+++ b/src/scene_synthesis/scene.py
@@ -54,11 +54,13 @@ class Scene(HasStrictTraits):
         c = self.environment.c
         mic_loc = np.array(mic.location)
         relative_loc = source_loc - mic_loc
+        source_to_mic = mic_loc - source_loc
         source_pos = np.asarray(source_loc, dtype=float).reshape(3, -1)
         distance = float(np.asarray(self.environment.apparent_r(source_pos, mic_loc)).reshape(-1)[0])
         spread = float(np.asarray(self.environment.spread(source_pos, mic_loc)).reshape(-1)[0])
+        target_direction = source_to_mic / distance
         radial_mach = float(np.dot(source_vel, relative_loc / distance) / c) if source.conv_amp else 0.0
-        return distance, spread, radial_mach
+        return distance, spread, radial_mach, target_direction
 
     def result(self, num=128):
         """
@@ -134,6 +136,7 @@ class Scene(HasStrictTraits):
                     new_receiving_times_list: list[float] = []
                     new_spreads_list: list[float] = []
                     new_radial_machs_list: list[float] = []
+                    new_target_directions_list: list[np.ndarray] = []
                     last_size = sent_signal_size_matrix[source_id, mic_id]
 
                     while not new_receiving_times_list or new_receiving_times_list[-1] < interpolation_space.max():
@@ -143,31 +146,45 @@ class Scene(HasStrictTraits):
 
                         sending_time = (last_sending_step_matrix[source_id, mic_id] + step) / sample_freq
                         source_loc, source_vel = self._source_state(source, sending_time)
-                        distance, spread, radial_mach = self._propagation_sample(source, source_loc, source_vel, mic)
+                        distance, spread, radial_mach, target_direction = self._propagation_sample(
+                            source, source_loc, source_vel, mic
+                        )
                         time_delays = distance / c
                         receiving_time = sending_time + time_delays
 
                         new_receiving_times_list.append(float(receiving_time))
                         new_spreads_list.append(spread)
                         new_radial_machs_list.append(radial_mach)
+                        new_target_directions_list.append(target_direction)
 
                         step += 1
 
                     new_receiving_times = np.array(new_receiving_times_list, dtype=float)
                     new_spreads = np.array(new_spreads_list, dtype=float)
                     new_radial_machs = np.array(new_radial_machs_list, dtype=float)
+                    if new_target_directions_list:
+                        new_target_directions = np.array(new_target_directions_list, dtype=float).T
+                    else:
+                        new_target_directions = np.empty((3, 0), dtype=float)
 
                     last_sending_step_matrix[source_id, mic_id] += step
 
-                    # Fetch new signal samples for this iteration
-                    signal = source.signal.signal()[last_size : last_size + new_receiving_times.size]
+                    # Fetch local source strength samples for this iteration.
+                    # Always use ``local_strength`` instead of the raw signal so
+                    # source-specific radiation laws and frequency-dependent
+                    # transformations are applied before propagation.
+                    local_strength = source.local_strength(self.environment)[last_size : last_size + new_receiving_times.size]
+                    direction_factor = source.direction_factor(new_target_directions)
                     sent_signal_size_matrix[source_id, mic_id] += new_receiving_times.size
 
-                    # Apply geometric spreading from the environment and
-                    # Doppler effect correction.
-                    # Something about the normalization factor of 4 pi is wrong.
-                    # Probably has something to do with the radial Mach number.
-                    new_squished_signal = signal * new_spreads / np.square(1 - new_radial_machs)  # / 4 / np.pi
+                    # Apply source directivity, geometric spreading from the
+                    # environment, and Doppler effect correction.
+                    new_squished_signal = (
+                        local_strength
+                        * direction_factor
+                        * new_spreads
+                        / np.square(1 - new_radial_machs)
+                    )
 
                     # Combine carry-over tail from previous block with newly generated samples.
                     prev_times = carry_receiving_times[source_id][mic_id]

--- a/src/scene_synthesis/sources.py
+++ b/src/scene_synthesis/sources.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from acoular import SignalGenerator, Trajectory
-from traits.api import CArray, HasStrictTraits, Instance
+from traits.api import Bool, CArray, HasStrictTraits, Instance
 
 from scene_synthesis.directivities import Directivity
 
@@ -21,7 +21,12 @@ class Source(HasStrictTraits):
     >>> source = Source(signal=signal, trajectory=trajectory)
     """
 
-    #: The signal of the source.
+    #: Virtual source-time signal.
+    #:
+    #: Samples live on the source/emission time axis. The base class does not
+    #: define the physical quantity represented by this signal. Subclasses must
+    #: specify whether samples represent pressure, volume velocity, force,
+    #: acceleration, or another source-strength quantity.
     signal = Instance(SignalGenerator)
 
     #: The (initial) 3D location of the source.
@@ -31,7 +36,7 @@ class Source(HasStrictTraits):
     trajectory = Instance(Trajectory)
 
     #: Whether to apply amplitude convection correction.
-    conv_amp = Instance(bool, value=False)
+    conv_amp = Bool(False)
 
     #: Vectors defining the (initial) global orientation of the source
     #: These vectors must be orthogonal to each other
@@ -42,3 +47,102 @@ class Source(HasStrictTraits):
 
     #: The directivity of the source.
     directivity = Instance(Directivity)
+
+    def local_strength(self, environment):  # noqa: ARG002
+        """Return source-time local strength signal.
+
+        Base source keeps legacy behavior: the signal is already the local
+        strength. Physical source subclasses should override this method so
+        frequency-dependent radiation laws are always applied before
+        propagation.
+        """
+        return np.asarray(self.signal.signal(), dtype=float)
+
+    def direction_factor(self, target_directions):
+        """Return direction-dependent source factor.
+
+        Base source is omnidirectional. ``target_directions`` has shape
+        ``(3, N)`` and contains source-to-receiver unit vectors.
+        """
+        return np.ones(target_directions.shape[1], dtype=float)
+
+
+class MonopoleSource(Source):
+    """Ideal monopole source driven by volume velocity.
+
+    For a monopole, :attr:`signal` is assumed to be given as the source volume
+    velocity signal ``Q(t)`` in ``m**3/s``.
+
+    The free-field far-field pressure of a stationary monopole in time domain is
+
+    ``p(r, t) = rho0 / (4*pi*r) * dQ/dt(t - r/c)``.
+
+    Since propagation delay and geometric spreading are handled by the scene,
+    the source provides a local source strength which handles the radiation law
+    of the source. The time reference is source-based, meaning the pressure
+    strength colocated with the source is reduced to
+
+    ``p_s(t) = rho0 / (4*pi) * dQ/dt(t)``.
+    """
+
+    def local_strength(self, environment):
+        q = self.signal.signal()
+        return environment.rho0 / (4 * np.pi) * np.diff(q, prepend=0.0) * self.signal.sample_freq
+
+
+class DipoleSource(Source):
+    """Ideal compact dipole source driven by prescribed force.
+
+    For a dipole, :attr:`signal` is assumed to be the source-time point force
+    ``F_p(t)`` in ``N`` acting on the fluid along ``orientation[2]``. This is
+    analogous to :class:`MonopoleSource`, where the signal prescribes volume
+    velocity ``Q(t)`` directly: radiation impedance matters for source loading,
+    radiated power, and mapping an actuator drive to ``F_p(t)``, but this ideal
+    source model does not solve that coupling.
+
+    The source center is :attr:`location`. The dipole axis is
+    ``orientation[2]``. The time-domain equation has the same
+    propagation shape as the monopole equation:
+
+    ``p(r, t) = cos(theta) / r * dF_p/dt(t - r/c) / (4*pi*c)``.
+
+    The factor ``cos(theta)`` is geometric and must be computed from the dipole
+    axis and the source-to-receiver direction during propagation.
+
+    Separation theorem for this compact model: a finite opposite-monopole pair
+    has coupled frequency/direction response ``2j*sin(k*d*cos(theta)/2)``. In
+    the point-dipole limit, with finite spacing condensed into ``F_p(t)``, this
+    becomes the separable form ``j*k * F_p * cos(theta)``. The ``j*k`` high-pass
+    is represented here by the time derivative in :meth:`force_derivative`;
+    :meth:`direction_factor` keeps only the compact-limit angular term. Finite
+    spacing effects such as lobing require a finite-pair model instead.
+    """
+
+    def axis(self):
+        """Return normalized global dipole axis."""
+        axis = np.asarray(self.orientation[2], dtype=float)
+        norm = np.linalg.norm(axis)
+        if norm == 0.0:
+            msg = 'dipole axis must be non-zero'
+            raise ValueError(msg)
+        return axis / norm
+
+    def force_derivative(self):
+        """Return source-time ``dF/dt``."""
+        return np.diff(self.signal.signal(), prepend=0.0) * self.signal.sample_freq
+
+    def direction_factor(self, target_directions):
+        """Return ``cos(theta)`` for source-to-receiver directions.
+
+        ``target_directions`` must have shape ``(3, N)``. Each column is a unit
+        vector from source to receiver in global coordinates.
+        """
+        return np.dot(self.axis(), target_directions)
+
+    def local_strength(self, environment):
+        """Return source-time force-dipole strength.
+
+        Propagation must apply retarded time, geometric spreading ``1/r``, and
+        ``cos(theta)`` from :meth:`direction_factor`.
+        """
+        return self.force_derivative() / (4 * np.pi * environment.c)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,150 @@
+"""Unit tests for acoustic source models."""
+
+import numpy as np
+import acoular as ac
+import scene_synthesis as ss
+from traits.api import CArray
+
+
+class ArraySignal(ac.SignalGenerator):
+    """Signal generator backed by fixed samples."""
+
+    samples = CArray(dtype=float)
+
+    def _get_digest(self):
+        """Return stable test digest."""
+        return 'array-signal'
+
+    def signal(self):
+        """Return fixed signal samples."""
+        return self.samples
+
+
+class SilentLocalSource(ss.Source):
+    """Source with nonzero raw signal but zero local strength."""
+
+    def local_strength(self, environment):  # noqa: ARG002
+        """Return zero source strength."""
+        return np.zeros(self.signal.num_samples)
+
+
+def spherical_surface(radius, n_theta=25, n_phi=50):
+    """Return points and area weights for midpoint integration on a sphere."""
+    theta_edges = np.linspace(0.0, np.pi, n_theta + 1)
+    phi_edges = np.linspace(0.0, 2.0 * np.pi, n_phi + 1)
+    theta = 0.5 * (theta_edges[:-1] + theta_edges[1:])
+    phi = 0.5 * (phi_edges[:-1] + phi_edges[1:])
+    theta_grid, phi_grid = np.meshgrid(theta, phi, indexing='ij')
+
+    points = radius * np.vstack(
+        [
+            (np.sin(theta_grid) * np.cos(phi_grid)).ravel(),
+            (np.sin(theta_grid) * np.sin(phi_grid)).ravel(),
+            np.cos(theta_grid).ravel(),
+        ]
+    )
+    dtheta = np.diff(theta_edges)[:, np.newaxis]
+    dphi = np.diff(phi_edges)[np.newaxis, :]
+    weights = (radius**2 * np.sin(theta_grid) * dtheta * dphi).ravel()
+    return points, weights
+
+
+def propagate_periodic(source_strength, distances, sample_freq, sound_speed):
+    """Apply periodic retarded-time propagation for test signals."""
+    spectrum = np.fft.rfft(source_strength)
+    frequencies = np.fft.rfftfreq(source_strength.size, 1.0 / sample_freq)
+    phase = np.exp(-2j * np.pi * frequencies[:, np.newaxis] * distances[np.newaxis, :] / sound_speed)
+    return np.fft.irfft(spectrum[:, np.newaxis] * phase, n=source_strength.size, axis=0)
+
+
+def test_monopole_local_strength_is_source_time_derivative():
+    """Monopole local strength should be rho0/(4*pi) times dQ/dt_s."""
+    q = np.array([0.0, 1.0, 3.0, 6.0])
+    sample_freq = 2.0
+    environment = ss.Environment(rho0=1.5)
+    signal = ArraySignal(samples=q, sample_freq=sample_freq, num_samples=q.size)
+    source = ss.MonopoleSource(signal=signal)
+
+    local_strength = source.local_strength(environment)
+
+    expected = environment.rho0 / (4 * np.pi) * np.diff(q, prepend=0.0) * sample_freq
+    np.testing.assert_allclose(local_strength, expected)
+
+
+def test_monopole_local_strength_scales_with_environment_density():
+    """Monopole local strength should use the active environment density."""
+    q = np.array([0.0, 1.0, 2.0])
+    signal = ArraySignal(samples=q, sample_freq=1.0, num_samples=q.size)
+    source = ss.MonopoleSource(signal=signal)
+
+    low_density = source.local_strength(ss.Environment(rho0=1.0))
+    high_density = source.local_strength(ss.Environment(rho0=2.0))
+
+    np.testing.assert_allclose(high_density, 2.0 * low_density)
+
+
+def test_scene_uses_local_strength_instead_of_raw_signal():
+    """Scene synthesis should propagate local strength, not raw signal."""
+    num_samples = 256
+    sample_freq = 1024.0
+    time = np.arange(num_samples) / sample_freq
+    raw_signal = np.sin(2 * np.pi * 64.0 * time)
+    signal = ArraySignal(samples=raw_signal, sample_freq=sample_freq, num_samples=num_samples)
+    source = SilentLocalSource(signal=signal, location=[1.0, 0.0, 0.0])
+    microphone = ss.Microphone(location=np.array([0.0, 0.0, 0.0]))
+    scene = ss.Scene(environment=ss.Environment(), microphones=[microphone], sources=[source])
+
+    result = np.concatenate(list(scene.result(num=64)))
+
+    np.testing.assert_allclose(result, 0.0)
+
+
+def test_scene_applies_source_direction_factor():
+    """Scene synthesis should apply dipole direction factors during propagation."""
+    num_samples = 512
+    sample_freq = 2048.0
+    time = np.arange(num_samples) / sample_freq
+    force = np.sin(2 * np.pi * 64.0 * time)
+    signal = ArraySignal(samples=force, sample_freq=sample_freq, num_samples=num_samples)
+    source = ss.DipoleSource(signal=signal, location=[0.0, 0.0, 0.0])
+    environment = ss.Environment()
+
+    perpendicular_mic = ss.Microphone(location=np.array([1.0, 0.0, 0.0]))
+    perpendicular_scene = ss.Scene(environment=environment, microphones=[perpendicular_mic], sources=[source])
+    perpendicular = np.concatenate(list(perpendicular_scene.result(num=64)))
+
+    axial_mic = ss.Microphone(location=np.array([0.0, 0.0, 1.0]))
+    axial_scene = ss.Scene(environment=environment, microphones=[axial_mic], sources=[source])
+    axial = np.concatenate(list(axial_scene.result(num=64)))
+
+    np.testing.assert_allclose(perpendicular, 0.0, atol=1e-12)
+    assert np.max(np.abs(axial)) > 0.0
+
+
+def test_monopole_finite_volume_velocity_power_integrates_on_sphere():
+    """Propagated pressure on a sphere should integrate to monopole power."""
+    sample_freq = 8192.0
+    num_samples = 8192
+    source_frequency = 64.0
+    radius = 2.0
+    time = np.arange(num_samples) / sample_freq
+    q = np.sin(2 * np.pi * source_frequency * time)
+    environment = ss.Environment(rho0=1.2041, c=343.0)
+    signal = ArraySignal(samples=q, sample_freq=sample_freq, num_samples=num_samples)
+    source = ss.MonopoleSource(signal=signal)
+
+    source_strength = source.local_strength(environment)
+    points, area_weights = spherical_surface(radius)
+    distances = environment.apparent_r(np.array([[0.0], [0.0], [0.0]]), points).ravel()
+    spread = environment.spread(np.array([[0.0], [0.0], [0.0]]), points).ravel()
+    pressure = propagate_periodic(source_strength, distances, sample_freq, environment.c) * spread
+    mean_square_pressure = np.mean(pressure**2, axis=0)
+    numeric_radiated_power = np.sum(area_weights * mean_square_pressure / (environment.rho0 * environment.c))
+
+    wave_number = 2 * np.pi * source_frequency / environment.c
+    expected_radiated_power = np.mean(q**2) * environment.rho0 * environment.c * wave_number**2 / (4 * np.pi)
+
+    assert np.all(np.isfinite(pressure))
+    assert np.allclose(distances, radius)
+    np.testing.assert_allclose(area_weights.sum(), 4 * np.pi * radius**2, rtol=7e-4)
+    np.testing.assert_allclose(numeric_radiated_power, expected_radiated_power, rtol=2e-3)


### PR DESCRIPTION
Added monopole and dipole.

The current level of complexity is:

**Monopole:**  
- Assumes a given signal to be a volume velocity time signal $q(t)$
- Computes the derivative of $q(t)$ in **local** (not retarded!) time in time domain
- Utilizes $\varrho_0$ as description for medium

**Dipole:**  
- Assumes a given signal to be a compact oscillating point force $F_p(t)$ that already describes radiation impedance, similar to the monopole source signal requirements
- Due to compactness, it can separate the angular factor from the derivative/frequency factor
- Also in local time domain
- Uses $c$ for medium
- Required a slight modification of `scene.py` to accept the directional factor.


**The user has to be very clear on what they use as input signals in relation to the intended physical meaning!**